### PR TITLE
Removing Json.net Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ project.lock.json
 .idea/
 obj/
 .DS_Store
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio 2015 cache/options directory
+.vs/

--- a/src/EntityQueryLanguage.DataApi/EntityQueryLanguage.DataApi.csproj
+++ b/src/EntityQueryLanguage.DataApi/EntityQueryLanguage.DataApi.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/EntityQueryLanguage/EntityQueryLanguage.csproj
+++ b/src/EntityQueryLanguage/EntityQueryLanguage.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Antlr4" Version="4.6.4" />
     <PackageReference Include="Antlr4.Runtime" Version="4.6.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Changed two things:

- added a few .gitignore entries from opening in VS2017.
- Removed Json.net Dependency. It wasn't being used by anything, and was set to v11. This makes running from an Azure Function annoyingly difficult. Azure Functions have some known issues with locked dependencies, Json.Net being one of them (Functions all run directly in the host, which already is locked to Json.Net 9.0.1). Best to just remove the dependency.
